### PR TITLE
[Optional for the release] Doxygen comments cleaning + compiler warnings removal

### DIFF
--- a/src/saber/bump/tools_fit.F90
+++ b/src/saber/bump/tools_fit.F90
@@ -14,7 +14,7 @@ use type_mpl, only: mpl_type
 
 implicit none
 
-integer,parameter :: itermax = 10 ! Maximum number of iteration for the threshold definition
+integer,parameter :: itermax = 10 !< Maximum number of iteration for the threshold definition
 
 private
 public :: fast_fit,ver_smooth,ver_fill

--- a/src/saber/bump/tools_func.F90
+++ b/src/saber/bump/tools_func.F90
@@ -1089,7 +1089,7 @@ real(kind_real),intent(out) :: l(1:kz)      ! Eigenvalues of Bx
 integer,intent(out) :: ierr                 ! Error status
 
 ! Local variables
-integer :: work,m,info
+integer :: work,m
 real(kind_real) :: work_array(1:3*kz-1),ecopy(1:kz,1:kz),lcopy(1:kz)
 
 ! Initialization

--- a/src/saber/bump/tools_func.F90
+++ b/src/saber/bump/tools_func.F90
@@ -17,11 +17,11 @@ use type_mpl, only: mpl_type
 
 implicit none
 
-real(kind_real),parameter :: gc2gau = 0.28            ! GC99 support radius to Gaussian Daley length-scale (empirical)
-real(kind_real),parameter :: gau2gc = 3.57            ! Gaussian Daley length-scale to GC99 support radius (empirical)
-real(kind_real),parameter :: Dmin = 1.0e-12_kind_real ! Minimum tensor diagonal value
-real(kind_real),parameter :: condmax = 1.0e3          ! Maximum tensor conditioning number
-integer,parameter :: M = 0                            ! Number of implicit iteration for the Matern function (0: Gaussian)
+real(kind_real),parameter :: gc2gau = 0.28            !< GC99 support radius to Gaussian Daley length-scale (empirical)
+real(kind_real),parameter :: gau2gc = 3.57            !< Gaussian Daley length-scale to GC99 support radius (empirical)
+real(kind_real),parameter :: Dmin = 1.0e-12_kind_real !< Minimum tensor diagonal value
+real(kind_real),parameter :: condmax = 1.0e3          !< Maximum tensor conditioning number
+integer,parameter :: M = 0                            !< Number of implicit iteration for the Matern function (0: Gaussian)
 
 interface
    function c_fletcher32(n,var) bind(c,name='fletcher32') result(hash)

--- a/src/saber/bump/tools_func.F90
+++ b/src/saber/bump/tools_func.F90
@@ -130,7 +130,7 @@ implicit none
 real(kind_real),intent(in) :: lon_i !< Initial point longitude (radians)
 real(kind_real),intent(in) :: lat_i !< Initial point latitude (radians)
 real(kind_real),intent(in) :: lon_f !< Final point longitude (radians)
-real(kind_real),intent(in) :: lat_f !< Final point longilatitudetude (radians)
+real(kind_real),intent(in) :: lat_f !< Final point latitude (radians)
 real(kind_real),intent(out) :: dist !< Great-circle distance
 
 ! Local variables

--- a/src/saber/bump/type_bump.F90
+++ b/src/saber/bump/type_bump.F90
@@ -34,6 +34,10 @@ use type_vbal, only: vbal_type
 
 implicit none
 
+integer,parameter :: dmsvali = -999           !< Default missing value for integers
+real(kind_real),parameter :: dmsvalr = -999.0 !< Default missing value for reals
+logical :: copy_ensemble = .false.            !< Deep copy of ensemble members
+
 ! BUMP derived type
 type bump_type
    type(bpar_type) :: bpar
@@ -93,10 +97,6 @@ contains
    procedure :: dealloc => bump_dealloc
    final :: dummy
 end type bump_type
-
-integer,parameter :: dmsvali = -999           ! Default missing value for integers
-real(kind_real),parameter :: dmsvalr = -999.0 ! Default missing value for reals
-logical :: copy_ensemble = .false.            ! Deep copy of ensemble members
 
 private
 public :: bump_type

--- a/src/saber/bump/type_bump.F90
+++ b/src/saber/bump/type_bump.F90
@@ -470,7 +470,7 @@ if (bump%nam%new_lct) then
    call bump%mpl%flush
    write(bump%mpl%info,'(a)') '--- Copy LCT into C matrix'
    call bump%mpl%flush
-   call bump%cmat%from_lct(bump%mpl,bump%nam,bump%geom,bump%bpar,bump%lct)
+   call bump%cmat%from_lct(bump%mpl,bump%geom,bump%bpar,bump%lct)
 
    ! Release memory (partial)
    call bump%lct%partial_dealloc
@@ -500,7 +500,7 @@ if (bump%cmat%allocated.or.bump%nam%new_nicas) then
    call bump%mpl%flush
    write(bump%mpl%info,'(a)') '--- Get C matrix from BUMP interface'
    call bump%mpl%flush
-   call bump%cmat%from_bump(bump%mpl,bump%nam,bump%geom,bump%bpar)
+   call bump%cmat%from_bump(bump%mpl,bump%geom,bump%bpar)
 
    ! Setup C matrix sampling
    write(bump%mpl%info,'(a)') '-------------------------------------------------------------------'

--- a/src/saber/bump/type_bump_interface.F90
+++ b/src/saber/bump/type_bump_interface.F90
@@ -5,7 +5,6 @@
 ! Licensing: this code is distributed under the CeCILL-C license
 ! Copyright © 2015-... UCAR,CERFACS,METEO-FRANCE and IRIT
 !----------------------------------------------------------------------
-
 module type_bump_interface
 
 use atlas_module, only: atlas_functionspace,atlas_fieldset
@@ -20,6 +19,7 @@ implicit none
 private
 
 contains
+
 !----------------------------------------------------------------------
 ! Subroutine: bump_create_c
 !> Create

--- a/src/saber/bump/type_cmat.F90
+++ b/src/saber/bump/type_cmat.F90
@@ -74,13 +74,12 @@ end subroutine cmat_alloc
 ! Subroutine: cmat_alloc_blk
 !> Allocation
 !----------------------------------------------------------------------
-subroutine cmat_alloc_blk(cmat,nam,geom,bpar)
+subroutine cmat_alloc_blk(cmat,geom,bpar)
 
 implicit none
 
 ! Passed variables
 class(cmat_type),intent(inout) :: cmat !< C matrix
-type(nam_type),intent(in) :: nam       !< Namelist
 type(geom_type),intent(in) :: geom     !< Geometry
 type(bpar_type),intent(in) :: bpar     !< Block parameters
 
@@ -91,7 +90,7 @@ integer :: ib
 do ib=1,bpar%nbe
    if (bpar%B_block(ib).and.bpar%nicas_block(ib)) then
       cmat%blk(ib)%ib = ib
-      call cmat%blk(ib)%alloc(nam,geom,bpar)
+      call cmat%blk(ib)%alloc(geom,bpar)
    end if
 end do
 
@@ -104,14 +103,13 @@ end subroutine cmat_alloc_blk
 ! Subroutine: cmat_init
 !> C matrix initialization
 !----------------------------------------------------------------------
-subroutine cmat_init(cmat,mpl,nam,bpar)
+subroutine cmat_init(cmat,mpl,bpar)
 
 implicit none
 
 ! Passed variables
 class(cmat_type),intent(inout) :: cmat !< C matrix
 type(mpl_type),intent(inout) :: mpl    !< MPI data
-type(nam_type),intent(in) :: nam       !< Namelist
 type(bpar_type),intent(in) :: bpar     !< Block parameters
 
 ! Local variables
@@ -119,7 +117,7 @@ integer :: ib
 
 ! Initialize blocks
 do ib=1,bpar%nbe
-   if (bpar%B_block(ib).and.bpar%nicas_block(ib)) call cmat%blk(ib)%init(mpl,nam,bpar)
+   if (bpar%B_block(ib).and.bpar%nicas_block(ib)) call cmat%blk(ib)%init(mpl,bpar)
 end do
 
 end subroutine cmat_init
@@ -229,7 +227,7 @@ do ib=1,bpar%nbe
 end do
 
 ! Allocation
-call cmat%alloc(nam,geom,bpar)
+call cmat%alloc(geom,bpar)
 
 do ib=1,bpar%nbe
    if (bpar%B_block(ib).and.bpar%nicas_block(ib)) then
@@ -348,7 +346,7 @@ do ib=1,bpar%nbe
 end do
 
 ! Allocation
-call cmat%alloc(nam,geom,bpar)
+call cmat%alloc(geom,bpar)
 if (nam%local_diag) then
    allocate(fld_c2a(hdiag%samp%nc2a,geom%nl0,4))
    allocate(fld_c2b(hdiag%samp%nc2b,geom%nl0))
@@ -356,7 +354,7 @@ if (nam%local_diag) then
 end if
 
 ! Initialization
-call cmat%init(mpl,nam,bpar)
+call cmat%init(mpl,bpar)
 
 ! Convolution parameters
 do ib=1,bpar%nbe
@@ -514,14 +512,13 @@ end subroutine cmat_from_hdiag
 ! Subroutine: cmat_from_lct
 !> Import LCT into C matrix
 !----------------------------------------------------------------------
-subroutine cmat_from_lct(cmat,mpl,nam,geom,bpar,lct)
+subroutine cmat_from_lct(cmat,mpl,geom,bpar,lct)
 
 implicit none
 
 ! Passed variables
 class(cmat_type),intent(inout) :: cmat !< C matrix
 type(mpl_type),intent(inout) :: mpl    !< MPI data
-type(nam_type),intent(in) :: nam       !< Namelist
 type(geom_type),intent(in) :: geom     !< Geometry
 type(bpar_type),intent(in) :: bpar     !< Block parameters
 type(lct_type),intent(in) :: lct       !< LCT
@@ -539,10 +536,10 @@ do ib=1,bpar%nbe
 end do
 
 ! Allocation
-call cmat%alloc(nam,geom,bpar)
+call cmat%alloc(geom,bpar)
 
 ! Initialization
-call cmat%init(mpl,nam,bpar)
+call cmat%init(mpl,bpar)
 
 ! Convolution parameters
 do ib=1,bpar%nbe
@@ -617,10 +614,10 @@ if (.not.cmat%allocated) then
    end do
 
    ! Allocation
-   call cmat%alloc(nam,geom,bpar)
+   call cmat%alloc(geom,bpar)
 
    ! Initialization
-   call cmat%init(mpl,nam,bpar)
+   call cmat%init(mpl,bpar)
 end if
 
 ! Convolution parameters
@@ -648,14 +645,13 @@ end subroutine cmat_from_nam
 ! Subroutine: cmat_from_bump
 !> Import C matrix from BUMP
 !----------------------------------------------------------------------
-subroutine cmat_from_bump(cmat,mpl,nam,geom,bpar)
+subroutine cmat_from_bump(cmat,mpl,geom,bpar)
 
 implicit none
 
 ! Passed variables
 class(cmat_type),intent(inout) :: cmat !< C matrix
 type(mpl_type),intent(inout) :: mpl    !< MPI data
-type(nam_type),intent(in) :: nam       !< Namelist
 type(geom_type),intent(in) :: geom     !< Geometry
 type(bpar_type),intent(in) :: bpar     !< Block parameters
 
@@ -673,10 +669,10 @@ if (.not.cmat%allocated) then
    end do
 
    ! Allocation
-   call cmat%alloc(nam,geom,bpar)
+   call cmat%alloc(geom,bpar)
 
    ! Initialization
-   call cmat%init(mpl,nam,bpar)
+   call cmat%init(mpl,bpar)
 end if
 
 do ib=1,bpar%nbe

--- a/src/saber/bump/type_cmat_blk.F90
+++ b/src/saber/bump/type_cmat_blk.F90
@@ -62,13 +62,12 @@ contains
 ! Subroutine: cmat_blk_alloc
 !> Allocation
 !----------------------------------------------------------------------
-subroutine cmat_blk_alloc(cmat_blk,nam,geom,bpar)
+subroutine cmat_blk_alloc(cmat_blk,geom,bpar)
 
 implicit none
 
 ! Passed variables
 class(cmat_blk_type),intent(inout) :: cmat_blk !< C matrix data block
-type(nam_type),intent(in) :: nam               !< Namelist
 type(geom_type),intent(in) :: geom             !< Geometry
 type(bpar_type),intent(in) :: bpar             !< Block parameters
 
@@ -101,14 +100,13 @@ end subroutine cmat_blk_alloc
 ! Subroutine: cmat_blk_init
 !> Initialization
 !----------------------------------------------------------------------
-subroutine cmat_blk_init(cmat_blk,mpl,nam,bpar)
+subroutine cmat_blk_init(cmat_blk,mpl,bpar)
 
 implicit none
 
 ! Passed variables
 class(cmat_blk_type),intent(inout) :: cmat_blk !< C matrix data block
 type(mpl_type),intent(in) :: mpl               !< MPI data
-type(nam_type),intent(in) :: nam               !< Namelist
 type(bpar_type),intent(in) :: bpar             !< Block parameters
 
 ! Associate

--- a/src/saber/bump/type_diag.F90
+++ b/src/saber/bump/type_diag.F90
@@ -24,7 +24,7 @@ use type_samp, only: samp_type
 
 implicit none
 
-real(kind_real),parameter :: bound = 5.0_kind_real ! Restriction bound applied on local diagnostics with respect to the global diagnostic
+real(kind_real),parameter :: bound = 5.0_kind_real !< Restriction bound applied on local diagnostics with respect to the global diagnostic
 
 ! Diagnostic derived type
 type diag_type

--- a/src/saber/bump/type_diag_blk.F90
+++ b/src/saber/bump/type_diag_blk.F90
@@ -24,8 +24,8 @@ use type_samp, only: samp_type
 
 implicit none
 
-integer,parameter :: nsc = 50                          ! Number of iterations for the scaling optimization
-real(kind_real),parameter :: maxfactor = 2.0_kind_real ! Maximum factor for diagnostics with respect to the origin
+integer,parameter :: nsc = 50                          !< Number of iterations for the scaling optimization
+real(kind_real),parameter :: maxfactor = 2.0_kind_real !< Maximum factor for diagnostics with respect to the origin
 
 ! Diagnostic block derived type
 type diag_blk_type

--- a/src/saber/bump/type_geom.F90
+++ b/src/saber/bump/type_geom.F90
@@ -300,7 +300,7 @@ call geom%setup_c0(mpl)
 call geom%setup_tree(mpl)
 
 ! Setup meshes
-call geom%setup_meshes(mpl,rng,nam)
+call geom%setup_meshes(mpl,rng)
 
 ! Setup number of independent levels
 call geom%setup_independent_levels(mpl)
@@ -1087,7 +1087,7 @@ end subroutine geom_setup_tree
 ! Subroutine: geom_setup_meshes
 !> Setup meshes
 !----------------------------------------------------------------------
-subroutine geom_setup_meshes(geom,mpl,rng,nam)
+subroutine geom_setup_meshes(geom,mpl,rng)
 
 implicit none
 
@@ -1095,7 +1095,6 @@ implicit none
 class(geom_type),intent(inout) :: geom !< Geometry
 type(mpl_type),intent(inout) :: mpl    !< MPI data
 type(rng_type),intent(inout) :: rng    !< Random number generator
-type(nam_type),intent(in) :: nam       !< Namelist
 
 ! Local variables
 integer :: ic0a,ic0u,nnb,jnb,jc0u,jc0,jproc,nc0aplus,ic0aplus

--- a/src/saber/bump/type_linop.F90
+++ b/src/saber/bump/type_linop.F90
@@ -20,8 +20,8 @@ use type_rng, only: rng_type
 
 implicit none
 
-logical,parameter :: check_data = .false.             ! Activate data check for all linear operations
-real(kind_real),parameter :: S_inf = 1.0e-2_kind_real ! Minimum interpolation coefficient
+logical,parameter :: check_data = .false.             !< Activate data check for all linear operations
+real(kind_real),parameter :: S_inf = 1.0e-2_kind_real !< Minimum interpolation coefficient
 
 ! Interpolation data derived type
 type interp_type

--- a/src/saber/bump/type_mesh.F90
+++ b/src/saber/bump/type_mesh.F90
@@ -18,7 +18,7 @@ use type_rng, only: rng_type
 
 implicit none
 
-logical,parameter :: shuffle = .true. ! Shuffle mesh order (more efficient to compute the Delaunay triangulation)
+logical,parameter :: shuffle = .true. !< Shuffle mesh order (more efficient to compute the Delaunay triangulation)
 
 ! Mesh derived type
 type mesh_type

--- a/src/saber/bump/type_minim.F90
+++ b/src/saber/bump/type_minim.F90
@@ -16,6 +16,15 @@ use type_rng, only: rng_type
 
 implicit none
 
+! Praxis precision parameters
+real(kind_real),parameter :: machep = epsilon(1.0_kind_real) !< Machine precision
+real(kind_real),parameter :: small = machep**2               !< Small value
+real(kind_real),parameter :: vsmall = small**2               !< Very small value
+real(kind_real),parameter :: large = 1.0/small               !< Large value
+real(kind_real),parameter :: vlarge = 1.0/vsmall             !< Very large value
+real(kind_real),parameter :: m2 = sqrt(machep)               !< Machine precision square-root
+real(kind_real),parameter :: m4 = sqrt(m2)                   !< Square-root of the machine precision square-root
+
 ! Minimization data derived type
 type minim_type
    ! Minimizer data
@@ -79,15 +88,6 @@ contains
    procedure :: vt_dir => minim_vt_dir
    procedure :: vt_inv => minim_vt_inv
 end type minim_type
-
-! Praxis precision parameters
-real(kind_real),parameter :: machep = epsilon(1.0_kind_real)
-real(kind_real),parameter :: small = machep**2
-real(kind_real),parameter :: vsmall = small**2
-real(kind_real),parameter :: large = 1.0/small
-real(kind_real),parameter :: vlarge = 1.0/vsmall
-real(kind_real),parameter :: m2 = sqrt(machep)
-real(kind_real),parameter :: m4 = sqrt(m2)
 
 private
 public :: minim_type

--- a/src/saber/bump/type_mom.F90
+++ b/src/saber/bump/type_mom.F90
@@ -295,7 +295,7 @@ type(ens_type), intent(in) :: ens     !< Ensemble
 character(len=*),intent(in) :: prefix !< Prefix
 
 ! Local variables
-integer :: ie,ie_sub,ic0c,jc0c,jl0r,jl0,il0,isub,jc3,ic1a,ib,jv,iv,jts,its
+integer :: ie,ie_sub,ic0c,jc0c,jl0r,jl0,il0,isub,jc3,ic1a,ib,jv,iv
 real(kind_real) :: fld_c0a(geom%nc0a,geom%nl0,nam%nv)
 real(kind_real),allocatable :: fld_ext(:,:,:),fld_1(:,:),fld_2(:,:,:)
 logical,allocatable :: mask_unpack(:,:)

--- a/src/saber/bump/type_nam.F90
+++ b/src/saber/bump/type_nam.F90
@@ -224,7 +224,7 @@ class(nam_type),intent(out) :: nam !< Namelist
 integer,intent(in) :: nproc        !< Number of MPI task
 
 ! Local variable
-integer :: il,iv,its,i,ildwv
+integer :: il,iv,i,ildwv
 
 ! general_param default
 nam%datadir = '.'
@@ -1614,8 +1614,8 @@ class(nam_type),intent(inout) :: nam !< Namelist
 type(mpl_type),intent(inout) :: mpl  !< MPI data
 
 ! Local variables
-integer :: iv,its,i,il,idir,ildwv
-character(len=2) :: ivchar,itschar,ildwvchar
+integer :: iv,i,il,idir,ildwv
+character(len=2) :: ivchar,ildwvchar
 character(len=1024),parameter :: subr = 'nam_check'
 
 ! Check maximum sizes

--- a/src/saber/bump/type_nam.F90
+++ b/src/saber/bump/type_nam.F90
@@ -16,15 +16,15 @@ use type_mpl, only: mpl_type
 
 implicit none
 
-integer,parameter :: nvmax = 20                    ! Maximum number of variables
-integer,parameter :: nlmax = 200                   ! Maximum number of levels
-integer,parameter :: nc3max = 1000                 ! Maximum number of classes
-integer,parameter :: nscalesmax = 5                ! Maximum number of variables
-integer,parameter :: ndirmax = 300                 ! Maximum number of diracs
-integer,parameter :: nldwvmax = 99                 ! Maximum number of local diagnostic profiles
-integer,parameter :: nprociomax = 20               ! Maximum number of I/O tasks
-integer,parameter :: niokvmax = 30                 ! Maximum number of I/O key-values
-integer,parameter :: nvbalmax = nvmax*(nvmax-1)/2  ! Maximum number of vertical balance blocks
+integer,parameter :: nvmax = 20                    !< Maximum number of variables
+integer,parameter :: nlmax = 200                   !< Maximum number of levels
+integer,parameter :: nc3max = 1000                 !< Maximum number of classes
+integer,parameter :: nscalesmax = 5                !< Maximum number of variables
+integer,parameter :: ndirmax = 300                 !< Maximum number of diracs
+integer,parameter :: nldwvmax = 99                 !< Maximum number of local diagnostic profiles
+integer,parameter :: nprociomax = 20               !< Maximum number of I/O tasks
+integer,parameter :: niokvmax = 30                 !< Maximum number of I/O key-values
+integer,parameter :: nvbalmax = nvmax*(nvmax-1)/2  !< Maximum number of vertical balance blocks
 
 type nam_type
    ! general_param

--- a/src/saber/bump/type_nicas.F90
+++ b/src/saber/bump/type_nicas.F90
@@ -226,7 +226,7 @@ do iproc=1,mpl%nproc
                call mpl%ncerr(subr,nf90_inq_grp_ncid(ncid,grpname,grpid))
 
                ! Read data
-               call nicas%blk(ib)%read(mpl,nam,geom,bpar,grpid)
+               call nicas%blk(ib)%read(mpl,geom,bpar,grpid)
             end if
          end do
       else
@@ -240,7 +240,7 @@ do iproc=1,mpl%nproc
                call mpl%ncerr(subr,nf90_inq_grp_ncid(ncid,grpname,grpid))
 
                ! Read data
-               call nicas_tmp%blk(ib)%read(mpl,nam,geom,bpar,grpid)
+               call nicas_tmp%blk(ib)%read(mpl,geom,bpar,grpid)
             end if
          end do
 
@@ -327,7 +327,7 @@ do iproc=1,mpl%nproc
                grpid = mpl%nc_group_define_or_get(subr,ncid,grpname)
 
                ! Write data
-               call nicas%blk(ib)%write(mpl,nam,geom,bpar,grpid)
+               call nicas%blk(ib)%write(mpl,geom,bpar,grpid)
 
                if (nam%write_grids.and.bpar%nicas_block(ib)) then
                   ! Define group
@@ -353,7 +353,7 @@ do iproc=1,mpl%nproc
                grpid = mpl%nc_group_define_or_get(subr,ncid,grpname)
 
                ! Write data
-               call nicas_tmp%blk(ib)%write(mpl,nam,geom,bpar,grpid)
+               call nicas_tmp%blk(ib)%write(mpl,geom,bpar,grpid)
 
                if (nam%write_grids.and.bpar%nicas_block(ib)) then
                   ! Define group

--- a/src/saber/bump/type_nicas.F90
+++ b/src/saber/bump/type_nicas.F90
@@ -31,9 +31,9 @@ use type_rng, only: rng_type
 
 implicit none
 
-integer,parameter :: nfac_rnd = 9 ! Number of ensemble size factors for randomization
-integer,parameter :: nfac_opt = 4 ! Number of length-scale factors for optimization
-integer,parameter :: ntest = 50   ! Number of tests
+integer,parameter :: nfac_rnd = 9 !< Number of ensemble size factors for randomization
+integer,parameter :: nfac_opt = 4 !< Number of length-scale factors for optimization
+integer,parameter :: ntest = 50   !< Number of tests
 
 
 ! NICAS derived type

--- a/src/saber/bump/type_nicas_blk.F90
+++ b/src/saber/bump/type_nicas_blk.F90
@@ -30,9 +30,9 @@ use type_rng, only: rng_type
 
 implicit none
 
-real(kind_real),parameter :: sqrt_r = 0.725_kind_real ! Square-root factor on support radius (empirical)
-real(kind_real),parameter :: sqrt_h = 0.725_kind_real ! Square-root factor on LCT (empirical)
-real(kind_real),parameter :: S_inf = 1.0e-2_kind_real ! Minimum value for the convolution coefficients
+real(kind_real),parameter :: sqrt_r = 0.725_kind_real !< Square-root factor on support radius (empirical)
+real(kind_real),parameter :: sqrt_h = 0.725_kind_real !< Square-root factor on LCT (empirical)
+real(kind_real),parameter :: S_inf = 1.0e-2_kind_real !< Minimum value for the convolution coefficients
 
 ! Ball data derived type
 type balldata_type

--- a/src/saber/bump/type_nicas_blk.F90
+++ b/src/saber/bump/type_nicas_blk.F90
@@ -470,14 +470,13 @@ end subroutine nicas_blk_dealloc
 ! Subroutine: nicas_blk_read
 !> Read
 !----------------------------------------------------------------------
-subroutine nicas_blk_read(nicas_blk,mpl,nam,geom,bpar,ncid)
+subroutine nicas_blk_read(nicas_blk,mpl,geom,bpar,ncid)
 
 implicit none
 
 ! Passed variables
 class(nicas_blk_type),intent(inout) :: nicas_blk !< NICAS data
 type(mpl_type),intent(inout) :: mpl              !< MPI data
-type(nam_type),intent(in) :: nam                 !< Namelist
 type(geom_type),intent(in) :: geom               !< Geometry
 type(bpar_type),intent(in) :: bpar               !< Block parameters
 integer,intent(in) :: ncid                       !< NetCDF file
@@ -606,14 +605,13 @@ end subroutine nicas_blk_read
 ! Subroutine: nicas_blk_write
 !> Write
 !----------------------------------------------------------------------
-subroutine nicas_blk_write(nicas_blk,mpl,nam,geom,bpar,ncid)
+subroutine nicas_blk_write(nicas_blk,mpl,geom,bpar,ncid)
 
 implicit none
 
 ! Passed variables
 class(nicas_blk_type),intent(in) :: nicas_blk !< NICAS data block
 type(mpl_type),intent(inout) :: mpl           !< MPI data
-type(nam_type),intent(in) :: nam              !< Namelist
 type(geom_type),intent(in) :: geom            !< Geometry
 type(bpar_type),intent(in) :: bpar            !< Block parameters
 integer,intent(in) :: ncid                    !< NetCDF file
@@ -788,7 +786,7 @@ integer,intent(out) :: nbufl                  !< Buffer size (logical)
 
 ! Local variables
 integer :: nnbufi,nnbufr
-integer :: il0i,il1,il0
+integer :: il0i,il1
 
 ! Associate
 associate(ib=>nicas_blk%ib)
@@ -864,7 +862,7 @@ logical,intent(out) :: bufl(nbufl)            !< Buffer (logical)
 
 ! Local variables
 integer :: ibufi,ibufr,ibufl,nnbufi,nnbufr
-integer :: il0i,il1,il0
+integer :: il0i,il1
 logical,allocatable :: mask_c0a(:,:)
 character(len=1024),parameter :: subr = 'nicas_blk_serialize'
 
@@ -1040,7 +1038,7 @@ logical,intent(in) :: bufl(nbufl)                !< Buffer (logical)
 
 ! Local variables
 integer :: ibufi,ibufr,ibufl,nnbufi,nnbufr
-integer :: il0i,il1,il0
+integer :: il0i,il1
 logical,allocatable :: mask_c0a(:,:)
 character(len=1024),parameter :: subr = 'nicas_blk_deserialize'
 

--- a/src/saber/bump/type_samp.F90
+++ b/src/saber/bump/type_samp.F90
@@ -179,14 +179,13 @@ end subroutine samp_alloc_mask
 ! Subroutine: samp_alloc_other
 !> Allocation for other variables
 !----------------------------------------------------------------------
-subroutine samp_alloc_other(samp,nam,geom)
+subroutine samp_alloc_other(samp,nam)
 
 implicit none
 
 ! Passed variables
 class(samp_type),intent(inout) :: samp !< Sampling
 type(nam_type),intent(in) :: nam       !< Namelist
-type(geom_type),intent(in) :: geom     !< Geometry
 
 ! Initialization
 samp%sc2 = (trim(samp%name)=='vbal').or.(trim(samp%name)=='lct').or.((trim(samp%name)=='hdiag').and.nam%local_diag)
@@ -842,7 +841,7 @@ if (nam%nc2>nam%nc1) then
 end if
 
 ! Allocation
-call samp%alloc(nam,geom)
+call samp%alloc(nam)
 
 if (nam%sam_read) then
    ! Read sampling
@@ -932,7 +931,7 @@ if ((trim(samp%name)=='hdiag').or.(trim(samp%name)=='lct')) then
    ! Compute MPI distribution, halo C
    write(mpl%info,'(a7,a)') '','Compute MPI distribution, halo C'
    call mpl%flush
-   call samp%compute_mpi_c(mpl,rng,nam,geom)
+   call samp%compute_mpi_c(mpl,nam,geom)
 end if
 
 if ((trim(samp%name)=='hdiag').and.nam%local_diag) then
@@ -1776,22 +1775,20 @@ end subroutine samp_compute_mesh_c2
 ! Subroutine: samp_compute_mpi_c
 !> Compute sampling MPI distribution, halo C
 !----------------------------------------------------------------------
-subroutine samp_compute_mpi_c(samp,mpl,rng,nam,geom)
+subroutine samp_compute_mpi_c(samp,mpl,nam,geom)
 
 implicit none
 
 ! Passed variables
 class(samp_type),intent(inout) :: samp !< Sampling
 type(mpl_type),intent(inout) :: mpl    !< MPI data
-type(rng_type),intent(inout) :: rng    !< Random number generator
 type(nam_type),intent(in) :: nam       !< Namelist
 type(geom_type),intent(in) :: geom     !< Geometry
 
 ! Local variables
-integer :: jc3,ic0,ic0a,ic0c,ic0u,jc0u,jc0c,ic1a,il0,i_s,iproc
+integer :: jc3,ic0,ic0a,ic0c,ic0u,jc0u,jc0c,ic1a,iproc
 integer :: c0u_to_c0c(geom%nc0u)
 integer,allocatable :: c0c_to_c0(:)
-real(kind_real),allocatable :: lon_c1a(:),lat_c1a(:)
 logical :: lcheck_c0c(geom%nc0u)
 
 ! Define halo C

--- a/src/saber/bump/type_tree.F90
+++ b/src/saber/bump/type_tree.F90
@@ -18,6 +18,8 @@ use type_mpl, only: mpl_type
 
 implicit none
 
+real(kind_real),parameter :: nn_inc = 1.5 !< Increase factor for the nearest neighbors numbers search
+
 ! Tree derived type
 type tree_type
     integer :: n                          !< Data size
@@ -34,8 +36,6 @@ contains
     procedure :: find_nearest_neighbors => tree_find_nearest_neighbors
     procedure :: count_nearest_neighbors => tree_count_nearest_neighbors
 end type tree_type
-
-real(kind_real),parameter :: nn_inc = 1.5 ! Increase factor for the nearest neighbors numbers search
 
 private
 public :: tree_type

--- a/src/saber/external/tools_asa007.F90
+++ b/src/saber/external/tools_asa007.F90
@@ -18,7 +18,7 @@ use type_mpl, only: mpl_type
 
 implicit none
 
-real(kind_real),parameter :: eta = 1.0e-9_kind_real   ! Small parameter for the Cholesky decomposition
+real(kind_real),parameter :: eta = 1.0e-9_kind_real !< Small parameter for the Cholesky decomposition
 
 private
 public :: asa007_cholesky,asa007_syminv

--- a/src/saber/external/tools_sp.F90
+++ b/src/saber/external/tools_sp.F90
@@ -14,12 +14,12 @@ use tools_const, only: pi
 implicit none
 
 private
-real(kind=kind_real),parameter:: ZERO    = 0.0_kind_real
-real(kind=kind_real),parameter:: ONE     = 1.0_kind_real
-real(kind=kind_real),parameter:: TWO     = 2.0_kind_real
-real(kind=kind_real),parameter:: TEN     = 10.0_kind_real
-real(kind=kind_real),parameter:: HALF    = 0.5_kind_real
-real(kind=kind_real),parameter:: QUARTER = 0.25_kind_real
+real(kind=kind_real),parameter:: ZERO    = 0.0_kind_real  !< Zero
+real(kind=kind_real),parameter:: ONE     = 1.0_kind_real  !< One
+real(kind=kind_real),parameter:: TWO     = 2.0_kind_real  !< Two
+real(kind=kind_real),parameter:: TEN     = 10.0_kind_real !< Ten
+real(kind=kind_real),parameter:: HALF    = 0.5_kind_real  !< Half
+real(kind=kind_real),parameter:: QUARTER = 0.25_kind_real !< Quarter
 
 public :: splat
 

--- a/src/saber/gaugrid/type_gaugrid.F90
+++ b/src/saber/gaugrid/type_gaugrid.F90
@@ -16,9 +16,9 @@ use tools_sp,    only: splat
 implicit none
 
 private
-real(kind=kind_real):: zero = 0.0_kind_real
-real(kind=kind_real):: two  = 2.0_kind_real
-real(kind=kind_real):: half = 0.5_kind_real
+real(kind=kind_real):: zero = 0.0_kind_real            !< Zero
+real(kind=kind_real):: two  = 2.0_kind_real            !< Two
+real(kind=kind_real):: half = 0.5_kind_real            !< Half
 
 ! Gaussian grid derived type
 type gaussian_grid

--- a/src/saber/interpolation/bump_interpolation_mod.F90
+++ b/src/saber/interpolation/bump_interpolation_mod.F90
@@ -2,25 +2,24 @@
 !
 ! This software is licensed under the terms of the Apache Licence Version 2.0
 ! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-
-!> \brief Bump Interpolation module
-!!
+! ------------------------------------------------------------------------------
+! Module: bump_interpolation_mod
+!> BUMP interpolation module
 !!
 !! \date Jan, 2020: Created by M. Miesch (JCSDA/UCAR) based on previously exising type_obsop.F90
 !! written by Benjamin Menetrier (JCSDA/UCAR, CERFACS, METEO-FRANCE, IRIT)
-!!
+! ------------------------------------------------------------------------------
 module bump_interpolation_mod
 
-use atlas_module
-use atlas_metadata_module, only: atlas_Metadata
-use fckit_configuration_module, only : fckit_configuration
+use atlas_module, only: atlas_functionspace,atlas_field,atlas_real
+use fckit_configuration_module, only: fckit_configuration
 use fckit_log_module, only: fckit_log
-use fckit_mpi_module, only: fckit_mpi_comm, fckit_mpi_sum,fckit_mpi_min,&
-                            fckit_mpi_max,fckit_mpi_status
+use fckit_mpi_module, only: fckit_mpi_comm,fckit_mpi_sum,fckit_mpi_min,fckit_mpi_max,fckit_mpi_status
+use iso_c_binding, only: c_char
 use netcdf
-use tools_atlas
+use tools_atlas, only: field_from_array,field_to_array
 use tools_const, only: pi,deg2rad,rad2deg
-use tools_func, only: lonlatmod, sphere_dist
+use tools_func, only: lonlatmod,sphere_dist
 use tools_kinds, only: kind_real
 use tools_qsort, only: qsort
 use tools_repro, only: rth
@@ -35,625 +34,561 @@ use type_nam, only: nam_type
 use type_rng, only: rng_type
 
 implicit none
-private
 
+private
 public :: bump_interpolator
 public :: bump_interpolator_registry
 
-integer, parameter :: max_string = 1024
+integer,parameter :: max_string = 1024 !< Maximum string size
 
-! ------------------------------------------------------------------------------
-!!
-!! bint = shorthand for bump interpolator
-!!
+! BUMP interpolator type
 type bump_interpolator
-private
-  type(bump_type), public :: bump
+   private
 
-  !> Grid information
-  type(geom_type) :: outgeom    !<< output grid - unstructured
-  type(atlas_functionspace) :: in_funcspace  !<< atlas functionspace for input grid
-  type(atlas_functionspace) :: out_funcspace !<< atlas functionspace for output grid
+   ! BUMP object
+   type(bump_type),public :: bump             !< BUMP
 
-  !> Number of points
-  integer :: nc0b                !<< Halo B size
-  integer, public :: nlev        !<< number of levels
+   ! Grid information
+   type(geom_type) :: outgeom                 !< Output grid - unstructured
+   type(atlas_functionspace) :: in_funcspace  !< ATLAS functionspace for input grid
+   type(atlas_functionspace) :: out_funcspace !< ATLAS functionspace for output grid
 
-  integer, public :: nout         !<< global number of output grid points
-  integer, public :: nout_local   !<< local number of output grid points
+   ! Number of points
+   integer :: nc0b                            !< Halo B size
+   integer,public :: nlev                     !< Number of levels
+   integer,public :: nout                     !< Global number of output grid points
+   integer,public :: nout_local               !< Local number of output grid points
 
-  !> Interpolation data (operator)
-  type(linop_type) :: h
+   ! Interpolation data (operator)
+   type(linop_type) :: h                      !< Interpolation operator
 
-  !> Communication data
-  type(com_type) :: com
-
+   ! Communication data
+   type(com_type) :: com                      !< Communication data
 contains
   private
 
-  procedure, private :: driver => bint_driver
-
-  procedure, public :: init => bint_init
-
-  procedure, public :: apply => bint_apply
-  procedure, public :: apply_ad => bint_apply_ad
-
+  procedure,private :: driver => bint_driver
+  procedure,public :: init => bint_init
+  procedure,public :: apply => bint_apply
+  procedure,public :: apply_ad => bint_apply_ad
   procedure :: deallocate_outgrid => bint_deallocate_outgrid
-  procedure, public :: delete => bint_delete
-
-  ! low-level apply methods
-  procedure, private :: apply_interp, apply_interp_ad
+  procedure,public :: delete => bint_delete
+  procedure,private :: apply_interp
+  procedure,private :: apply_interp_ad
   final :: dummy
-
 end type bump_interpolator
 
-! ------------------------------------------------------------------------------
-!> Registry for bump_interpolator objects
-
+! BUMP interpolator registry
 #define LISTED_TYPE bump_interpolator
 
-!> Linked list interface - defines registry_t type
+! Linked list interface - defines registry_t type
 #include "saber/util/linkedList_i.f"
 
-!> Global registry
+! Global registry
 type(registry_t) :: bump_interpolator_registry
 
-! ------------------------------------------------------------------------------
-
 contains
-!-------------------------------------------------------------------------------
-!> Linked list implementation
+
+!----------------------------------------------------------------------
+! Linked list implementation
+!----------------------------------------------------------------------
 #include "saber/util/linkedList_c.f"
 
 ! ------------------------------------------------------------------------------
-!> Initialize interpolation object
-!!
-!! The input and output fields are atlas_FieldSet objects that are assumed
-!! to be created from atlas functionspaces.  So, they have the grid and
+! Subroutine: bint_init
+!> Initialize interpolation object.
+!! The input and output fields are ATLAS_FieldSet objects that are assumed
+!! to be created from ATLAS functionspaces. So, they have the grid and
 !! mesh information built in.
-!!
-!! \param[in] config = configuration
-!!
-!! \param[in] in_afs = This is the input grid, rendered as an atlas
-!! functionspace, so it includes information about the mesh (parallel
-!! connectivity) as well.
-!!
-!! \param[in] out_afs = This is the output grid, also represented as
-!! an altas_functionspace.
-!!
-!! \param[in] masks = This contains metadata needed for the interpolation.
-!!  It is rendered as an atlas FieldSet with the following named fields.
-!!  Each of these named fields is optional; if omitted default values will
-!!  be provided
-!! * area  : cell area
-!! * vunit : vertical unit
-!! * gmask : geometry mask
-!! * smask : sampling mask
-!!
-subroutine bint_init(self, config, comm, in_funcspace, out_funcspace, masks)
-  use fckit_configuration_module, only : fckit_configuration
-  use iso_c_binding, only : c_char
-  class(bump_interpolator), intent(inout) :: self
-  class(fckit_configuration), intent(in)  :: config
-  type(fckit_mpi_comm)      , intent(in)  :: comm
-  class(atlas_functionspace), intent(in)  :: in_funcspace
-  class(atlas_functionspace), intent(in)  :: out_funcspace
-  type(fieldset_type)       , intent(in), optional :: masks
+! ------------------------------------------------------------------------------
+subroutine bint_init(self,config,comm,in_funcspace,out_funcspace,masks)
 
-  ! local variables
-  type(fckit_configuration) :: bump_config
-  integer :: msvali, j
-  real(kind_real) :: msvalr
-  integer, allocatable :: levels(:)
-  character(len=max_string) :: msg
-  character(len=max_string) :: myname = "saber::interpolation::bump_interpolation_mod::bint_init "
+implicit none
 
-  !--------------------------------------------------------------------------------
-  ! set bump namelist parameters.
+! Passed variables
+class(bump_interpolator),intent(inout) :: self         !< BUMP interpolator
+class(fckit_configuration),intent(in) :: config        !< Configuration
+type(fckit_mpi_comm),intent(in) :: comm                !< Communicator
+class(atlas_functionspace),intent(in) :: in_funcspace  !< Input grid, rendered as an ATLAS functionspace, so it includes information about the mesh (parallel connectivity) as well.
+class(atlas_functionspace),intent(in) :: out_funcspace !< Output grid, also represented as an altas_functionspace.
+type(fieldset_type),intent(in),optional :: masks       !< Metadata needed for the interpolation, rendered as an ATLAS FieldSet with the following named fields: area (cell area), vunit (vertical unit), gmask (geometry mask) and smask (sampling mask). Each of these named fields is optional, if omitted default values will be provided
 
-  call config%get_or_die("bump",bump_config)
+! Local variables
+type(fckit_configuration) :: bump_config
+integer :: msvali,j
+real(kind_real) :: msvalr
+integer,allocatable :: levels(:)
+character(len=max_string) :: msg
+character(len=max_string) :: myname = "saber::interpolation::bump_interpolation_mod::bint_init "
 
-  ! bump defaults
-  call self%bump%nam%init(comm%size())  ! set up defaults
+! Set BUMP namelist parameters.
+call config%get_or_die("bump",bump_config)
 
-  ! modified defaults for bump interpolator
-  self%bump%nam%default_seed = .true.
-  self%bump%nam%prefix       = 'bump_interpolator'
-  self%bump%nam%datadir      = 'testdata'
+! BUMP defaults
+call self%bump%nam%init(comm%size())
 
-  ! optionally override defaults with config
-  call self%bump%nam%from_conf(bump_config)
+! Modified defaults for BUMP interpolator
+self%bump%nam%default_seed = .true.
+self%bump%nam%prefix = 'bump_interpolator'
+self%bump%nam%datadir = 'testdata'
 
-  ! optional missing values for integers and reals
-  msvali = -999
-  msvalr = -999.0
-  If (config%has("missingvalue_int")) &
-       call config%get_or_die("missingvalue_int",msvali)
-  If (config%has("missingvalue_real")) &
-       call config%get_or_die("missingvalue_real",msvalr)
+! Optionally override defaults with config
+call self%bump%nam%from_conf(bump_config)
 
-  ! save these for future use
-  self%in_funcspace = in_funcspace
-  self%out_funcspace = out_funcspace
+! Optional missing values for integers and reals
+msvali = -999
+msvalr = -999.0
+if (config%has("missingvalue_int")) call config%get_or_die("missingvalue_int",msvali)
+if (config%has("missingvalue_real")) call config%get_or_die("missingvalue_real",msvalr)
 
-  !--------------------------------------------------------------------------------
-  ! determine the number of vertical levels
+! Save these for future use
+self%in_funcspace = in_funcspace
+self%out_funcspace = out_funcspace
 
-  self%nlev = 1
-  If (config%has("nlevels")) call config%get_or_die("nlevels",self%nlev)
+! Determine the number of vertical levels
+self%nlev = 1
+if (config%has("nlevels")) call config%get_or_die("nlevels",self%nlev)
+self%bump%nam%nl = self%nlev
+allocate(levels(1:self%nlev))
+if (config%has("levels")) then
+   call config%get_or_die("levels",levels)
+else
+   do j=1,self%nlev
+      levels(j) = j
+   end do
+end if
+self%bump%nam%levs(1:self%nlev) = levels
+deallocate(levels)
 
-  self%bump%nam%nl = self%nlev
+! Initialize BUMP
 
-  allocate(levels(1:self%nlev))
-  if (config%has("levels")) then
-     call config%get_or_die("levels",levels)
-  else
-     do j = 1, self%nlev
-        levels(j) = j
-     enddo
-  endif
-  self%bump%nam%levs(1:self%nlev) = levels
-  deallocate(levels)
+! Clear any pre-existing data
+call self%delete
 
-  !--------------------------------------------------------------------------------
-  ! Initialize BUMP
-  ! ---------------
+! Basic BUMP setup
+if (present(masks)) then
+   call self%bump%setup(self%bump%mpl%f_comm,in_funcspace,masks,msvali=msvali,msvalr=msvalr)
+else
+   call self%bump%setup(self%bump%mpl%f_comm,in_funcspace,msvali=msvali,msvalr=msvalr)
+end if
 
-  ! clear any pre-existing data
-  call self%delete
+! Initialize output grid
+call fckit_log%info('-------------------------------------------------------------------')
+call fckit_log%info('--- Initialize output grid')
+self%outgeom%nl0 = self%nlev
 
-  ! basic bump setup
-  if (present(masks)) then
-     call self%bump%setup(self%bump%mpl%f_comm, in_funcspace, masks, &
-          msvali=msvali, msvalr=msvalr)
-  else
-     call self%bump%setup(self%bump%mpl%f_comm, in_funcspace, &
-          msvali=msvali, msvalr=msvalr)
-  endif
+! Unpack output grid from output functionspace
+call self%outgeom%from_atlas(self%bump%mpl,out_funcspace)
+self%nout_local = size(self%outgeom%lon_mga)
 
-  !--------------------------------------------------------------------------------
-  ! initialize output grid
+! Run basic BUMP drivers
+call self%bump%run_drivers
 
-  call fckit_log%info('-------------------------------------------------------------------')
-  call fckit_log%info('--- Initialize output grid')
+! Run interpolation driver
+call fckit_log%info('-------------------------------------------------------------------')
+call fckit_log%info('--- Run bump_interpolation driver')
+call self%driver(self%bump%mpl,self%bump%rng,self%bump%nam,self%bump%geom)
+if (self%bump%nam%default_seed) call self%bump%rng%reseed(self%bump%mpl)
 
-  self%outgeom%nl0 = self%nlev
-
-  ! unpack output grid from output functionspace
-  call self%outgeom%from_atlas(self%bump%mpl, out_funcspace)
-  self%nout_local = size(self%outgeom%lon_mga)
-
-  !--------------------------------------------------------------------------------
-  ! Run basic BUMP drivers
-  ! The only thing here that may be needed is to possibly run the nicas driver
-  ! after we get things to work, try commenting this out and see if it still works
-  call self%bump%run_drivers
-
-  ! Run interpolation driver
-  call fckit_log%info('-------------------------------------------------------------------')
-  call fckit_log%info('--- Run bump_interpolation driver')
-  call self%driver(self%bump%mpl,self%bump%rng,self%bump%nam,self%bump%geom)
-  if (self%bump%nam%default_seed) call self%bump%rng%reseed(self%bump%mpl)
-
-  !--------------------------------------------------------------------------------
-  ! more initializations and checks that the setup is correct
-
-  if (self%nout < 1) then
-     write(msg,'(a)') trim(myname) // ": " // "Output grid not properly defined"
-     call abor1_ftn(msg)
-  endif
-
-  if (self%nlev /= self%bump%geom%nl0) then
-  write(msg,'(a)') trim(myname) // ": " // &
-                             "number of levels does not match bump geom"
-  call abor1_ftn(msg)
-  endif
-
-  if (self%nlev /= self%outgeom%nl0) then
-     write(msg,'(a)') trim(myname) // ": " // &
-          "ERROR: Output grid has different number of levels than input grid!"
-     call abor1_ftn(msg)
-  endif
-
-  !--------------------------------------------------------------------------------
+! More initializations and checks that the setup is correct
+if (self%nout < 1) then
+   write(msg,'(a)') trim(myname)//": output grid not properly defined"
+   call abor1_ftn(msg)
+end if
+if (self%nlev /= self%bump%geom%nl0) then
+   write(msg,'(a)') trim(myname)//": number of levels does not match bump geom"
+   call abor1_ftn(msg)
+end if
+if (self%nlev /= self%outgeom%nl0) then
+   write(msg,'(a)') trim(myname)//": output grid has different number of levels than input grid!"
+   call abor1_ftn(msg)
+end if
 
 end subroutine bint_init
 
 ! ------------------------------------------------------------------------------
-! ------------------------------------------------------------------------------
-!> Initialize bump to perform interpolation.
-!!
+! Subroutine: bint_driver
+!> Initialize BUMP to perform interpolation
 !----------------------------------------------------------------------
 subroutine bint_driver(self,mpl,rng,nam,geom)
-  class(bump_interpolator), intent(inout) :: self
-  type(mpl_type),intent(inout) :: mpl      !<< MPI data
-  type(rng_type),intent(inout) :: rng      !<< Random number generator
-  type(nam_type),intent(in) :: nam         !<< Namelist
-  type(geom_type),intent(in) :: geom       !<< Geometry
 
-  ! Local variables
-  integer :: iouta,iproc,i_s,ic0,ic0u,jc0u,ic0b,ic0a,nouta_eff
-  integer :: nout_eff,nn_index(1),proc_to_nouta(mpl%nproc),proc_to_nouta_eff(mpl%nproc)
-  integer :: c0u_to_c0b(geom%nc0u)
-  integer,allocatable :: c0b_to_c0(:)
-  real(kind_real) :: nn_dist(1),N_max,C_max
-  logical :: maskouta(self%nout_local),lcheck_nc0b(geom%nc0)
-  character(len=1024),parameter :: subr = 'bint_driver'
+implicit none
 
-  ! Check that universe is global
-  if (any(.not.geom%myuniverse)) call mpl%abort(subr,'universe should be global for interpolation')
+! Passed variables
+class(bump_interpolator),intent(inout) :: self !< BUMP interpolator
+type(mpl_type),intent(inout) :: mpl            !< MPI data
+type(rng_type),intent(inout) :: rng            !< Random number generator
+type(nam_type),intent(in) :: nam               !< Namelist
+type(geom_type),intent(in) :: geom             !< Geometry
 
-  ! Check whether output grid points are inside the mesh
-  if (self%nout_local > 0) then
-     do iouta=1,self%nout_local
-        call geom%mesh_c0u%inside(mpl,self%outgeom%lon_mga(iouta),self%outgeom%lat_mga(iouta),maskouta(iouta))
-        if (.not.maskouta(iouta)) then
-           ! Check for very close points
-           call geom%tree_c0u%find_nearest_neighbors(self%outgeom%lon_mga(iouta),self%outgeom%lat_mga(iouta), &
+! Local variables
+integer :: iouta,iproc,i_s,ic0,ic0u,jc0u,ic0b,ic0a,nouta_eff
+integer :: nout_eff,nn_index(1),proc_to_nouta(mpl%nproc),proc_to_nouta_eff(mpl%nproc)
+integer :: c0u_to_c0b(geom%nc0u)
+integer,allocatable :: c0b_to_c0(:)
+real(kind_real) :: nn_dist(1),N_max,C_max
+logical :: maskouta(self%nout_local),lcheck_nc0b(geom%nc0)
+character(len=1024),parameter :: subr = 'bint_driver'
+
+! Check that universe is global
+if (any(.not.geom%myuniverse)) call mpl%abort(subr,'universe should be global for interpolation')
+
+! Check whether output grid points are inside the mesh
+if (self%nout_local > 0) then
+   do iouta=1,self%nout_local
+      call geom%mesh_c0u%inside(mpl,self%outgeom%lon_mga(iouta),self%outgeom%lat_mga(iouta),maskouta(iouta))
+      if (.not.maskouta(iouta)) then
+         ! Check for very close points
+         call geom%tree_c0u%find_nearest_neighbors(self%outgeom%lon_mga(iouta),self%outgeom%lat_mga(iouta), &
  & 1,nn_index,nn_dist)
-           if (nn_dist(1)<rth) maskouta(iouta) = .true.
-        end if
-     end do
-     nouta_eff = count(maskouta)
-  else
-     nouta_eff = 0
-  endif
+         if (nn_dist(1)<rth) maskouta(iouta) = .true.
+      end if
+   end do
+   nouta_eff = count(maskouta)
+else
+   nouta_eff = 0
+end if
 
-  ! Get global number of output grid points
-  call mpl%f_comm%allgather(self%nout_local,proc_to_nouta)
-  call mpl%f_comm%allgather(nouta_eff,proc_to_nouta_eff)
-  self%nout = sum(proc_to_nouta)
-  nout_eff = sum(proc_to_nouta_eff)
+! Get global number of output grid points
+call mpl%f_comm%allgather(self%nout_local,proc_to_nouta)
+call mpl%f_comm%allgather(nouta_eff,proc_to_nouta_eff)
+self%nout = sum(proc_to_nouta)
+nout_eff = sum(proc_to_nouta_eff)
 
-  ! Print input
-  write(mpl%info,'(a7,a)') '','Number of points in output grid / valid points per MPI task:'
-  call mpl%flush
-  do iproc=1,mpl%nproc
-     write(mpl%info,'(a10,a,i3,a,i8,a,i8)') '','Task ',iproc,': ', &
-           proc_to_nouta(iproc),' / ',proc_to_nouta_eff(iproc)
-     call mpl%flush
-  end do
-  write(mpl%info,'(a10,a,i8,a,i8)') '','Total   : ',self%nout,' / ',nout_eff
-  call mpl%flush
+! Print input
+write(mpl%info,'(a7,a)') '','Number of points in output grid / valid points per MPI task:'
+call mpl%flush
+do iproc=1,mpl%nproc
+   write(mpl%info,'(a10,a,i3,a,i8,a,i8)') '','Task ',iproc,': ',proc_to_nouta(iproc),' / ',proc_to_nouta_eff(iproc)
+   call mpl%flush
+end do
+write(mpl%info,'(a10,a,i8,a,i8)') '','Total   : ',self%nout,' / ',nout_eff
+call mpl%flush
 
-  ! Compute interpolation
-  self%h%prefix = 'o'
-  write(mpl%info,'(a7,a)') '','Single level:'
-  call mpl%flush
-  call self%h%interp(mpl,rng,nam,geom,0,geom%nc0u,geom%lon_c0u,geom%lat_c0u,&
-                     geom%gmask_hor_c0u,self%nout_local,self%outgeom%lon_mga,&
-                     self%outgeom%lat_mga,maskouta,10)
+! Compute interpolation
+self%h%prefix = 'o'
+write(mpl%info,'(a7,a)') '','Single level:'
+call mpl%flush
+call self%h%interp(mpl,rng,nam,geom,0,geom%nc0u,geom%lon_c0u,geom%lat_c0u,geom%gmask_hor_c0u,self%nout_local,self%outgeom%lon_mga,&
+ & self%outgeom%lat_mga,maskouta,10)
 
-  ! Define halo B
-  lcheck_nc0b = .false.
-  do ic0a=1,geom%nc0a
-     ic0u = geom%c0a_to_c0u(ic0a)
-     lcheck_nc0b(ic0u) = .true.
-  end do
-  do iouta=1,self%nout_local
-     do i_s=1,self%h%n_s
-        jc0u = self%h%col(i_s)
-        lcheck_nc0b(jc0u) = .true.
-     end do
-  end do
-  self%nc0b = count(lcheck_nc0b)
+! Define halo B
+lcheck_nc0b = .false.
+do ic0a=1,geom%nc0a
+   ic0u = geom%c0a_to_c0u(ic0a)
+   lcheck_nc0b(ic0u) = .true.
+end do
+do iouta=1,self%nout_local
+   do i_s=1,self%h%n_s
+      jc0u = self%h%col(i_s)
+      lcheck_nc0b(jc0u) = .true.
+   end do
+end do
+self%nc0b = count(lcheck_nc0b)
 
-  ! Allocation
-  allocate(c0b_to_c0(self%nc0b))
+! Allocation
+allocate(c0b_to_c0(self%nc0b))
 
-  ! Global-local conversion for halo B
-  c0u_to_c0b = mpl%msv%vali
-  ic0b = 0
-  do ic0u=1,geom%nc0u
-     if (lcheck_nc0b(ic0u)) then
-        ic0b = ic0b+1
-        ic0 = geom%c0u_to_c0(ic0u)
-        c0b_to_c0(ic0b) = ic0
-        c0u_to_c0b(ic0u) = ic0b
-     end if
-  end do
+! Global-local conversion for halo B
+c0u_to_c0b = mpl%msv%vali
+ic0b = 0
+do ic0u=1,geom%nc0u
+   if (lcheck_nc0b(ic0u)) then
+      ic0b = ic0b+1
+      ic0 = geom%c0u_to_c0(ic0u)
+      c0b_to_c0(ic0b) = ic0
+      c0u_to_c0b(ic0u) = ic0b
+   end if
+end do
 
-  ! Local interpolation source
-  self%h%n_src = self%nc0b
-  do i_s=1,self%h%n_s
-     self%h%col(i_s) = c0u_to_c0b(self%h%col(i_s))
-  end do
+! Local interpolation source
+self%h%n_src = self%nc0b
+do i_s=1,self%h%n_s
+   self%h%col(i_s) = c0u_to_c0b(self%h%col(i_s))
+end do
 
-  ! Setup communications
-  call self%com%setup(mpl,'com',geom%nc0a,self%nc0b,geom%nc0,geom%c0a_to_c0,c0b_to_c0)
+! Setup communications
+call self%com%setup(mpl,'com',geom%nc0a,self%nc0b,geom%nc0,geom%c0a_to_c0,c0b_to_c0)
 
-  ! Compute scores
-  if (nout_eff > 0) then
-     call mpl%f_comm%allreduce(real(self%com%nhalo,kind_real),C_max,fckit_mpi_max())
-     C_max = C_max/(3.0*real(nout_eff,kind_real)/real(mpl%nproc,kind_real))
-     N_max = real(maxval(proc_to_nouta_eff),kind_real)/(real(nout_eff,kind_real)/real(mpl%nproc,kind_real))
+! Compute scores
+if (nout_eff > 0) then
+   call mpl%f_comm%allreduce(real(self%com%nhalo,kind_real),C_max,fckit_mpi_max())
+   C_max = C_max/(3.0*real(nout_eff,kind_real)/real(mpl%nproc,kind_real))
+   N_max = real(maxval(proc_to_nouta_eff),kind_real)/(real(nout_eff,kind_real)/real(mpl%nproc,kind_real))
 
-     ! Print results
-     write(mpl%info,'(a7,a,f5.1,a)') '','Output grid repartition imbalance: ',100.0*real(maxval(proc_to_nouta_eff) &
+   ! Print results
+   write(mpl%info,'(a7,a,f5.1,a)') '','Output grid repartition imbalance: ',100.0*real(maxval(proc_to_nouta_eff) &
  & -minval(proc_to_nouta_eff),kind_real)/(real(sum(proc_to_nouta_eff),kind_real)/real(mpl%nproc,kind_real)),' %'
-     call mpl%flush
-     write(mpl%info,'(a7,a,i8,a,i8,a,i8)') '','Number of grid points / halo size / number of received values: ', &
+   call mpl%flush
+   write(mpl%info,'(a7,a,i8,a,i8,a,i8)') '','Number of grid points / halo size / number of received values: ', &
  & self%com%nred,' / ',self%com%next,' / ',self%com%nhalo
-     call mpl%flush
-     write(mpl%info,'(a7,a,f10.2,a,f10.2)') '','Scores (N_max / C_max):',N_max,' / ',C_max
-     call mpl%flush
-  endif
+   call mpl%flush
+   write(mpl%info,'(a7,a,f10.2,a,f10.2)') '','Scores (N_max / C_max):',N_max,' / ',C_max
+   call mpl%flush
+end if
 
-  ! Release memory
-  deallocate(c0b_to_c0)
+! Release memory
+deallocate(c0b_to_c0)
 
 end subroutine bint_driver
 
 ! ------------------------------------------------------------------------------
-! ------------------------------------------------------------------------------
-!> Apply interpolation
-!!
-!! \param[in] instate = input fields represented as an atlas fieldset,
-!! created from a functionspace
-!!
-!! \param[out] outstate = output fields represented as an atlas fieldset.
-!! If the fields that constitudte the fieldset are not already allocated by
+! Subroutine bint_apply
+!> Apply interpolation.
+!! If the fields that constitute the fieldset are not already allocated by
 !! the caller, then they will be created and allocated by this method.
 !! So, the user can optionally pass this routine an empty output fieldset.
-!!
-subroutine bint_apply(self, infields, outfields)
-  class(bump_interpolator), intent(inout) :: self
-  type(fieldset_type)     , intent(in)    :: infields
-  type(fieldset_type)     , intent(inout) :: outfields
+! ------------------------------------------------------------------------------
+subroutine bint_apply(self,infields,outfields)
 
-  ! local variables
-  type(atlas_field) :: infield, outfield
-  real(kind_real), allocatable :: infld_mga(:,:), infld_c0a(:,:)
-  real(kind_real), allocatable :: outfld(:,:)
-  integer :: ifield
-  character(len=max_string) :: fieldname
+implicit none
 
-  ! allocate bump arrays
-  allocate(infld_mga(self%bump%geom%nmga,self%nlev))
-  allocate(outfld(self%nout_local,self%nlev))
+! Passed variables
+class(bump_interpolator),intent(inout) :: self !< BUMP interpolator
+type(fieldset_type),intent(in) :: infields     !< Input fields represented as an ATLAS fieldset, created from a functionspace
+type(fieldset_type),intent(inout) :: outfields !< Output fields represented as an ATLAS fieldset
 
-  if (.not.self%bump%geom%same_grid) then
-     allocate(infld_c0a(self%bump%geom%nc0a, self%nlev))
-  endif
+! Local variables
+type(atlas_field) :: infield,outfield
+real(kind_real),allocatable :: infld_mga(:,:),infld_c0a(:,:)
+real(kind_real),allocatable :: outfld(:,:)
+integer :: ifield
+character(len=max_string) :: fieldname
 
-  do ifield = 1, infields%size()
+! Allocation
+allocate(infld_mga(self%bump%geom%nmga,self%nlev))
+allocate(outfld(self%nout_local,self%nlev))
+if (.not.self%bump%geom%same_grid) then
+   allocate(infld_c0a(self%bump%geom%nc0a,self%nlev))
+end if
 
-     infield = infields%field(ifield)
-     fieldname = infield%name()
+do ifield=1,infields%size()
+   ! Copy field and field name
+   infield = infields%field(ifield)
+   fieldname = infield%name()
 
-     !--------------------------------------------
-     ! allocate output field if necessary
+   ! Allocation
+   if (.not. outfields%has_field(fieldname)) then
+      outfield = self%out_funcspace%create_field(name=fieldname,kind=atlas_real(kind_real),levels=self%nlev)
+   else
+      outfield = outfields%field(name=fieldname)
+   end if
 
-     if (.not. outfields%has_field(fieldname)) then
-        outfield = self%out_funcspace%create_field(name=fieldname, &
-             kind=atlas_real(kind_real),levels=self%nlev)
-     else
-        outfield = outfields%field(name=fieldname)
-     endif
+   ! ATLAS field to BUMP array
+   call field_to_array(self%bump%mpl,infield,infld_mga)
 
-     !--------------------------------------------
-     ! compute interpolation
+   if (self%bump%geom%same_grid) then
+      ! Apply interpolation
+      call self%apply_interp(infld_mga,outfld)
+   else
+      ! Model grid to subset Sc0
+      infld_c0a = 0.0_kind_real
+      call self%bump%geom%copy_mga_to_c0a(self%bump%mpl,infld_mga,infld_c0a)
 
-     ! atlas field to fortran array
-     call field_to_array(self%bump%mpl, infield, infld_mga)
+      ! Apply interpolation
+      call self%apply_interp(infld_c0a,outfld)
+   end if
 
-     if (self%bump%geom%same_grid) then
-        call self%apply_interp(infld_mga,outfld)
-     else
-        ! Model grid to subset Sc0
-        infld_c0a = 0.0_kind_real
-        call self%bump%geom%copy_mga_to_c0a(self%bump%mpl,infld_mga,infld_c0a)
+   ! BUMP array to ATLAS field
+   call field_from_array(self%bump%mpl,outfld,outfield)
 
-        ! Apply interpolation
-        call self%apply_interp(infld_c0a,outfld)
-     end if
+   ! Add output field to output fields
+   if (.not. outfields%has_field(fieldname)) then
+      call outfields%add(outfield)
+   end if
 
-     ! fortran array to atlas field
-     call field_from_array(self%bump%mpl, outfld, outfield)
+   ! Release pointers
+   call infield%final()
+   call outfield%final()
+end do
 
-     !--------------------------------------------
-     ! Add output field to output fields
-     if (.not. outfields%has_field(fieldname)) then
-        call outfields%add(outfield)
-     endif
-
-     ! release pointers
-     call infield%final()
-     call outfield%final()
-
-  enddo
-
-  ! clean up
-  if (allocated(infld_mga)) deallocate(infld_mga)
-  if (allocated(infld_c0a)) deallocate(infld_c0a)
-  if (allocated(outfld)) deallocate(outfld)
+! Release memory
+if (allocated(infld_mga)) deallocate(infld_mga)
+if (allocated(infld_c0a)) deallocate(infld_c0a)
+if (allocated(outfld)) deallocate(outfld)
 
 end subroutine bint_apply
 
 !----------------------------------------------------------------------
-!> Subroutine: apply_interp
-!! Purpose: low-level routine to apply the interpolation to a single
-!! field on a single level
-!! \param[in]  infield: input field
-!! \param[out] outfield: output field
-!!
+! Subroutine: apply_interp
+!> Low-level routine to apply the interpolation to a single field on a single level
+!----------------------------------------------------------------------
 subroutine apply_interp(self,infield,outfield)
-  class(bump_interpolator), intent(inout) :: self
-  real(kind_real)         , intent(in)    :: infield(self%bump%geom%nc0a,self%nlev)
-  real(kind_real)         , intent(out)   :: outfield(self%nout_local,self%nlev)
 
-  integer :: ilev
-  real(kind_real), allocatable :: infield_ext(:,:)
+implicit none
 
-  allocate(infield_ext(self%nc0b,self%nlev))
+! Passed variables
+class(bump_interpolator),intent(inout) :: self                       !< BUMP interpolator
+real(kind_real),intent(in) :: infield(self%bump%geom%nc0a,self%nlev) !< Input field
+real(kind_real),intent(out) :: outfield(self%nout_local,self%nlev)   !< Output field
 
-  ! Halo extension
-  call self%com%ext(self%bump%mpl, self%nlev, infield ,infield_ext)
+! Local variables
+integer :: ilev
+real(kind_real),allocatable :: infield_ext(:,:)
 
-  if (self%nout_local > 0) then
-     ! Horizontal interpolation
-     !$omp parallel do schedule(static) private(ilev)
-     do ilev = 1, self%nlev
-        call self%h%apply(self%bump%mpl,infield_ext(:,ilev),outfield(:,ilev))
-     end do
-     !$omp end parallel do
-  end if
+! Allocation
+allocate(infield_ext(self%nc0b,self%nlev))
 
-  deallocate(infield_ext)
+! Halo extension
+call self%com%ext(self%bump%mpl,self%nlev,infield,infield_ext)
+
+if (self%nout_local > 0) then
+   ! Horizontal interpolation
+   !$omp parallel do schedule(static) private(ilev)
+   do ilev=1,self%nlev
+      call self%h%apply(self%bump%mpl,infield_ext(:,ilev),outfield(:,ilev))
+   end do
+   !$omp end parallel do
+end if
+
+! Release memory
+deallocate(infield_ext)
 
 end subroutine apply_interp
 
 !----------------------------------------------------------------------
+!> Apply interpolator operator adjoint.
+!! The caller can optionally pass this arguement as an empty fieldset and the 
+!! routine will create and allocate each component of the fieldset. Or, if
+!! the field components of the fieldset are already allocated by the caller,
+!! then this routine will merely replace the field values with the result
+!! of the computation.
 !----------------------------------------------------------------------
-!> Apply interpolator operator adjoint
-!!
-!! \param[in] fields_outgrid = These are the fields on the second grid,
-!!  i.e. the target grid of the original interpolation.  For the adjoint,
-!!  these fields are treated as an input.
-!!
-!! \param[inout] fields_ingrid = These are the fields defined on the
-!! first grid, i.e. the source grid of the original interpolation.  For
-!! the adjoint, these are treated as an output.  The caller can optionally
-!! pass this arguement as an empty fieldset and the routine will create
-!! and allocate each component of the fieldset.  Or, if the field components
-!! of the fieldset are already allocated by the caller, then this routine
-!! will merely replace the field values with the result of the computation.
-!!
-!----------------------------------------------------------------------
-subroutine bint_apply_ad(self, fields_outgrid, fields_ingrid)
-  class(bump_interpolator), intent(inout) :: self
-  type(fieldset_type)     , intent(in)    :: fields_outgrid
-  type(fieldset_type)     , intent(inout) :: fields_ingrid
+subroutine bint_apply_ad(self,fields_outgrid,fields_ingrid)
 
-  ! Local variables
-  type(atlas_field) :: field_ingrid, field_outgrid
-  real(kind_real), allocatable :: fld_ingrid_mga(:,:), fld_ingrid_c0a(:,:)
-  real(kind_real), allocatable :: fld_outgrid(:,:)
-  integer :: ifield
-  character(len=max_string) :: fieldname
+implicit none
 
-  ! allocate bump arrays
-  allocate(fld_ingrid_mga(self%bump%geom%nmga,self%nlev))
-  allocate(fld_outgrid(self%nout_local,self%nlev))
+! Passed variables
+class(bump_interpolator),intent(inout) :: self     !< BUMP interpolator
+type(fieldset_type),intent(in) :: fields_outgrid   !< Fields on the second grid, i.e. the target grid of the original interpolation. For the adjoint, these fields are treated as an input.
+type(fieldset_type),intent(inout) :: fields_ingrid !< Fields defined on the first grid, i.e. the source grid of the original interpolation. For the adjoint, these are treated as an output.
 
-  if (.not.self%bump%geom%same_grid) then
-     allocate(fld_ingrid_c0a(self%bump%geom%nc0a, self%nlev))
-  endif
+! Local variables
+type(atlas_field) :: field_ingrid,field_outgrid
+real(kind_real),allocatable :: fld_ingrid_mga(:,:),fld_ingrid_c0a(:,:)
+real(kind_real),allocatable :: fld_outgrid(:,:)
+integer :: ifield
+character(len=max_string) :: fieldname
 
-  do ifield = 1, fields_outgrid%size()
+! Allocation
+allocate(fld_ingrid_mga(self%bump%geom%nmga,self%nlev))
+allocate(fld_outgrid(self%nout_local,self%nlev))
+if (.not.self%bump%geom%same_grid) then
+   allocate(fld_ingrid_c0a(self%bump%geom%nc0a,self%nlev))
+end if
 
-     field_outgrid = fields_outgrid%field(ifield)
-     fieldname = field_outgrid%name()
+do ifield=1,fields_outgrid%size()
+   ! Copy field and field name
+   field_outgrid = fields_outgrid%field(ifield)
+   fieldname = field_outgrid%name()
 
-     !--------------------------------------------
-     ! allocate output field if necessary
+   ! Allocation
+   if (.not. fields_ingrid%has_field(fieldname)) then
+      field_ingrid = self%in_funcspace%create_field(name=fieldname,kind=atlas_real(kind_real),levels=self%nlev)
+   else
+      field_ingrid = fields_ingrid%field(name=fieldname)
+   end if
 
-     if (.not. fields_ingrid%has_field(fieldname)) then
-        field_ingrid = self%in_funcspace%create_field(name=fieldname, &
-             kind=atlas_real(kind_real),levels=self%nlev)
-     else
-        field_ingrid = fields_ingrid%field(name=fieldname)
-     endif
+   ! ATLAS field to BUMP array
+   call field_to_array(self%bump%mpl,field_outgrid,fld_outgrid)
+   if (self%bump%geom%same_grid) then
+      ! Apply observation operator adjoint
+      call self%apply_interp_ad(fld_outgrid,fld_ingrid_mga)
+   else
+      ! Apply observation operator adjoint
+      call self%apply_interp_ad(fld_outgrid,fld_ingrid_c0a)
 
-     !--------------------------------------------
-     ! compute interpolation adjoint
+      ! Subset Sc0 to model grid
+      call self%bump%geom%copy_c0a_to_mga(self%bump%mpl,fld_ingrid_c0a,fld_ingrid_mga)
+   end if
 
-     ! atlas field to bump fld
-     call field_to_array(self%bump%mpl, field_outgrid, fld_outgrid)
+   ! BUMP array to ATLAS field
+   call field_from_array(self%bump%mpl,fld_ingrid_mga,field_ingrid)
 
-     if (self%bump%geom%same_grid) then
-        ! Apply observation operator adjoint
-        call self%apply_interp_ad(fld_outgrid,fld_ingrid_mga)
-     else
-        ! Apply observation operator adjoint
-        call self%apply_interp_ad(fld_outgrid,fld_ingrid_c0a)
+   ! Add field to result
+   if (.not. fields_ingrid%has_field(fieldname)) then
+      call fields_ingrid%add(field_ingrid)
+   end if
 
-        ! Subset Sc0 to model grid
-        call self%bump%geom%copy_c0a_to_mga(self%bump%mpl,fld_ingrid_c0a,fld_ingrid_mga)
-     end if
+   ! Release pointers
+   call field_ingrid%final()
+   call field_outgrid%final()
+end do
 
-     ! bump fld to atlas field
-     call field_from_array(self%bump%mpl, fld_ingrid_mga, field_ingrid)
-
-     !--------------------------------------------
-
-     ! add field to result
-     if (.not. fields_ingrid%has_field(fieldname)) then
-        call fields_ingrid%add(field_ingrid)
-     endif
-
-     ! release pointers
-     call field_ingrid%final()
-     call field_outgrid%final()
-
-  enddo
-
-  ! clean up
-  if (allocated(fld_ingrid_mga)) deallocate(fld_ingrid_mga)
-  if (allocated(fld_ingrid_c0a)) deallocate(fld_ingrid_c0a)
-  if (allocated(fld_outgrid)) deallocate(fld_outgrid)
+! Release memory
+if (allocated(fld_ingrid_mga)) deallocate(fld_ingrid_mga)
+if (allocated(fld_ingrid_c0a)) deallocate(fld_ingrid_c0a)
+if (allocated(fld_outgrid)) deallocate(fld_outgrid)
 
 end subroutine bint_apply_ad
 
 !----------------------------------------------------------------------
-!> Subroutine: apply_interp_ad
-!! Purpose: low-level routine to apply the adjoint of the interpolation operator
+! Subroutine: apply_interp_ad
+!> Low-level routine to apply the adjoint of the interpolation operator
 !! to a single field on a single level
-!!
-!! \param[in]  mpl bump MPI data
-!! \param[in]  geom bump geometry data
-!! \param[in]  fld_outgrid field on output grid
-!! \param[out] fld_ingrid field on input grid
-!!
-
+!----------------------------------------------------------------------
 subroutine apply_interp_ad(self,fld_outgrid,fld_ingrid)
-  class(bump_interpolator), intent(inout) :: self
-  real(kind_real),intent(in)   :: fld_outgrid(self%nout_local,self%nlev)
-  real(kind_real),intent(out)  :: fld_ingrid(self%bump%geom%nc0a,self%nlev)
 
-  integer :: ilev
-  real(kind_real) :: fld_ingrid_ext(self%nc0b,self%nlev)
+implicit none
 
-  if (self%nout_local > 0) then
-     ! Horizontal interpolation
-     !$omp parallel do schedule(static) private(ilev)
-     do ilev = 1, self%nlev
-        call self%h%apply_ad(self%bump%mpl,fld_outgrid(:,ilev),fld_ingrid_ext(:,ilev))
-     end do
-     !$omp end parallel do
-  else
-     ! No observation on this task
-     fld_ingrid_ext = 0.0
-  end if
+! Passed variables
+class(bump_interpolator),intent(inout) :: self                           !< BUMP interpolator
+real(kind_real),intent(in) :: fld_outgrid(self%nout_local,self%nlev)     !< Field on input grid
+real(kind_real),intent(out) :: fld_ingrid(self%bump%geom%nc0a,self%nlev) !< Field on output grid
 
-  ! Halo reduction
-  call self%com%red(self%bump%mpl,self%nlev,fld_ingrid_ext,fld_ingrid)
+! Local variables
+integer :: ilev
+real(kind_real) :: fld_ingrid_ext(self%nc0b,self%nlev)
+
+if (self%nout_local > 0) then
+   ! Horizontal interpolation
+   !$omp parallel do schedule(static) private(ilev)
+   do ilev=1,self%nlev
+      call self%h%apply_ad(self%bump%mpl,fld_outgrid(:,ilev),fld_ingrid_ext(:,ilev))
+   end do
+   !$omp end parallel do
+else
+   ! No observation on this task
+   fld_ingrid_ext = 0.0
+end if
+
+! Halo reduction
+call self%com%red(self%bump%mpl,self%nlev,fld_ingrid_ext,fld_ingrid)
 
 end subroutine apply_interp_ad
 
 !----------------------------------------------------------------------
+! Subroutine: bint_deallocate_outgrid
 !> Release memory (partial) by deallocating output grid
 !----------------------------------------------------------------------
 subroutine bint_deallocate_outgrid(self)
-  class(bump_interpolator), intent(inout) :: self
 
-  ! Release memory
-  call self%outgeom%dealloc()
+implicit none
+
+! Passed variables
+class(bump_interpolator),intent(inout) :: self !< BUMP interpolator
+
+! Release memory
+call self%outgeom%dealloc()
 
 end subroutine bint_deallocate_outgrid
 
 ! ------------------------------------------------------------------------------
+! Subroutine: bint_delete
 !> Release all memory
 ! ------------------------------------------------------------------------------
-
 subroutine bint_delete(self)
-  class(bump_interpolator), intent(inout) :: self
 
-  call self%bump%dealloc()
+implicit none
 
-  call self%deallocate_outgrid()
-  call self%h%dealloc()
-  call self%com%dealloc()
+! Passed variables
+class(bump_interpolator),intent(inout) :: self !< BUMP interpolator
+
+! Release memory
+call self%bump%dealloc()
+call self%deallocate_outgrid()
+call self%h%dealloc()
+call self%com%dealloc()
 
 end subroutine bint_delete
 
@@ -661,12 +596,12 @@ end subroutine bint_delete
 ! Subroutine: dummy
 !> Dummy finalization
 !----------------------------------------------------------------------
-subroutine dummy(bump)
+subroutine dummy(self)
 
 implicit none
 
 ! Passed variables
-type(bump_interpolator),intent(inout) :: bump !< BUMP
+type(bump_interpolator),intent(inout) :: self !< BUMP interpolator
 
 end subroutine dummy
 

--- a/src/saber/interpolation/interpolatorbump_interface.F90
+++ b/src/saber/interpolation/interpolatorbump_interface.F90
@@ -2,10 +2,13 @@
 !
 ! This software is licensed under the terms of the Apache Licence Version 2.0
 ! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-
+! ------------------------------------------------------------------------------
+! Module: interpolatorbump_interface
+!> BUMP interpolation interface
+! ------------------------------------------------------------------------------
 module interpolatorbump_interface
 
-use atlas_module
+use atlas_module, only: atlas_functionspace,atlas_fieldset
 use fckit_configuration_module, only: fckit_configuration
 use fckit_mpi_module, only: fckit_mpi_comm
 use iso_c_binding
@@ -14,28 +17,30 @@ use bump_interpolation_mod
 use type_fieldset
 
 private
-! ------------------------------------------------------------------------------
+
 contains
+
 !-------------------------------------------------------------------------------
-!> Create Bump Interpolator (abbreviated as bint)
-!!
-subroutine bint_create_c(c_key_bint, c_comm, c_fspace1, c_fspace2, c_masks, &
-                         c_config) bind(c, name='bint_create_f90')
+! Subroutine bint_create_c
+!> Create BUMP interpolator (abbreviated as bint)
+!-------------------------------------------------------------------------------
+subroutine bint_create_c(c_key_bint,c_comm,c_fspace1,c_fspace2,c_masks,c_config) bind(c,name='bint_create_f90')
+
 implicit none
 
 ! Passed variables
-integer(c_int), intent(inout) :: c_key_bint !<< bump interpolator
-type(c_ptr), value, intent(in) :: c_comm    !<< MPI Communicator
-type(c_ptr), intent(in),value :: c_fspace1  !<< source grid (atlas functionspace)
-type(c_ptr), intent(in),value :: c_fspace2  !<< target grid (atlas functionspace)
-type(c_ptr), intent(in),value :: c_masks    !<< masks and other metadata
-type(c_ptr), value, intent(in) :: c_config  !<< Configuration
+integer(c_int),intent(inout) :: c_key_bint !< BUMP interpolator
+type(c_ptr),value,intent(in) :: c_comm     !< MPI Communicator
+type(c_ptr),intent(in),value :: c_fspace1  !< Source grid (atlas functionspace)
+type(c_ptr),intent(in),value :: c_fspace2  !< Target grid (atlas functionspace)
+type(c_ptr),intent(in),value :: c_masks    !< Masks and other metadata
+type(c_ptr),value,intent(in) :: c_config   !< Configuration
 
 ! local variables
-type(bump_interpolator), pointer :: bint
+type(bump_interpolator),pointer :: bint
 type(fckit_mpi_comm) :: f_comm
 type(fckit_configuration) :: f_config
-type(atlas_functionspace) :: fspace1, fspace2
+type(atlas_functionspace) :: fspace1,fspace2
 type(fieldset_type) :: masks
 
 f_comm = fckit_mpi_comm(c_comm)
@@ -43,88 +48,90 @@ f_config = fckit_configuration(c_config)
 
 call bump_interpolator_registry%init()
 call bump_interpolator_registry%add(c_key_bint)
-call bump_interpolator_registry%get(c_key_bint, bint)
+call bump_interpolator_registry%get(c_key_bint,bint)
 
 fspace1 = atlas_functionspace(c_fspace1)
 fspace2 = atlas_functionspace(c_fspace2)
 
 if (c_associated(c_masks)) then
    masks = atlas_fieldset(c_masks)
-   call bint%init(f_config, f_comm, fspace1, fspace2, masks)
+   call bint%init(f_config,f_comm,fspace1,fspace2,masks)
 else
-   call bint%init(f_config, f_comm, fspace1, fspace2)
+   call bint%init(f_config,f_comm,fspace1,fspace2)
 endif
 
 end subroutine bint_create_c
 
 !-------------------------------------------------------------------------------
-!> Apply Bump Interpolator
-!!
-subroutine bint_apply_c(c_key_bint, c_infields, c_outfields) bind(c, name='bint_apply_f90')
+! Subroutine: bint_apply_c
+!> Apply BUMP interpolator
+!-------------------------------------------------------------------------------
+subroutine bint_apply_c(c_key_bint,c_infields,c_outfields) bind(c,name='bint_apply_f90')
 
 implicit none
 
 ! Passed variables
-integer(c_int), intent(in) :: c_key_bint  !<< key to bump interpolator
-type(c_ptr), intent(in), value :: c_infields  !<< input fields
-type(c_ptr), intent(in), value :: c_outfields !<< output fields
+integer(c_int),intent(in) :: c_key_bint     !< Key to BUMP interpolator
+type(c_ptr),intent(in),value :: c_infields  !< Input fields
+type(c_ptr),intent(in),value :: c_outfields !< Output fields
 
 ! Local variables
-type(bump_interpolator), pointer :: bint
-type(fieldset_type) :: infields, outfields
+type(bump_interpolator),pointer :: bint
+type(fieldset_type) :: infields,outfields
 
-call bump_interpolator_registry%get(c_key_bint, bint)
+call bump_interpolator_registry%get(c_key_bint,bint)
 infields = atlas_fieldset(c_infields)
 outfields = atlas_fieldset(c_outfields)
 
-call bint%apply(infields, outfields)
+call bint%apply(infields,outfields)
 
 end subroutine bint_apply_c
 
 !-------------------------------------------------------------------------------
-!> Apply Bump Interpolator Adjoint
-!!
-subroutine bint_apply_ad_c(c_key_bint, c_fields2, c_fields1) bind(c, name='bint_apply_ad_f90')
+! Subroutine: bint_apply_ad_c
+!> Apply BUMP interpolator adjoint
+!-------------------------------------------------------------------------------
+subroutine bint_apply_ad_c(c_key_bint,c_fields2,c_fields1) bind(c,name='bint_apply_ad_f90')
 
 implicit none
 
 ! Passed variables
-integer(c_int), intent(in) :: c_key_bint    !<< key to bump interpolator
-type(c_ptr), intent(in), value :: c_fields2 !<< input fields
-type(c_ptr), intent(in), value :: c_fields1 !<< output fields
+integer(c_int),intent(in) :: c_key_bint   !< Key to BUMP interpolator
+type(c_ptr),intent(in),value :: c_fields2 !< Input fields
+type(c_ptr),intent(in),value :: c_fields1 !< Output fields
 
 ! Local variables
-type(bump_interpolator), pointer :: bint
-type(fieldset_type) :: fields_grid2, fields_grid1
+type(bump_interpolator),pointer :: bint
+type(fieldset_type) :: fields_grid2,fields_grid1
 
-call bump_interpolator_registry%get(c_key_bint, bint)
+call bump_interpolator_registry%get(c_key_bint,bint)
 fields_grid2 = atlas_fieldset(c_fields2)
 fields_grid1 = atlas_fieldset(c_fields1)
 
-call bint%apply_ad(fields_grid2, fields_grid1)
+call bint%apply_ad(fields_grid2,fields_grid1)
 
 end subroutine bint_apply_ad_c
 
-! ------------------------------------------------------------------------------
+!----------------------------------------------------------------------
+! Subroutine bint_delete_c
 !> Delete bump_interpolator
-subroutine bint_delete_c(c_key_bint) bind(c, name='bint_delete_f90')
+!----------------------------------------------------------------------
+subroutine bint_delete_c(c_key_bint) bind(c,name='bint_delete_f90')
 
 implicit none
 
 ! Passed variables
-integer(c_int), intent(inout) :: c_key_bint
+integer(c_int),intent(inout) :: c_key_bint !< Key to BUMP interpolator
 
 ! Local variables
-type(bump_interpolator), pointer :: bint
+type(bump_interpolator),pointer :: bint
 
-call bump_interpolator_registry%get(c_key_bint, bint)
+call bump_interpolator_registry%get(c_key_bint,bint)
 
 call bint%delete()
 
 call bump_interpolator_registry%remove(c_key_bint)
 
 end subroutine bint_delete_c
-
-! ------------------------------------------------------------------------------
 
 end module interpolatorbump_interface

--- a/src/saber/util/tools_const.F90
+++ b/src/saber/util/tools_const.F90
@@ -11,12 +11,12 @@ use tools_kinds, only: kind_real
 
 implicit none
 
-real(kind_real),parameter :: pi = acos(-1.0_kind_real)     ! Pi
-real(kind_real),parameter :: deg2rad = pi/180.0_kind_real  ! Degree to radian
-real(kind_real),parameter :: rad2deg = 180.0_kind_real/pi  ! Radian to degree
-real(kind_real),parameter :: req = 6371229.0_kind_real     ! Earth radius (in m)
-real(kind_real),parameter :: reqkm = 6371.229_kind_real    ! Earth radius (in km)
-real(kind_real),parameter :: ps = 101325.0_kind_real       ! Reference surface pressure (in Pa)
+real(kind_real),parameter :: pi = acos(-1.0_kind_real)     !< Pi
+real(kind_real),parameter :: deg2rad = pi/180.0_kind_real  !< Degree to radian
+real(kind_real),parameter :: rad2deg = 180.0_kind_real/pi  !< Radian to degree
+real(kind_real),parameter :: req = 6371229.0_kind_real     !< Earth radius (in m)
+real(kind_real),parameter :: reqkm = 6371.229_kind_real    !< Earth radius (in km)
+real(kind_real),parameter :: ps = 101325.0_kind_real       !< Reference surface pressure (in Pa)
 
 private
 public :: pi,deg2rad,rad2deg,req,reqkm,ps

--- a/src/saber/util/tools_kinds.F90
+++ b/src/saber/util/tools_kinds.F90
@@ -13,16 +13,16 @@ use netcdf, only: nf90_double
 implicit none
 
 ! Kinds
-integer,parameter :: kind_int = c_int                        ! Integer kind
-integer,parameter :: kind_short = c_short                    ! Short integer kind
-integer,parameter :: kind_real = c_double                    ! Real kind
+integer,parameter :: kind_int = c_int                        !< Integer kind
+integer,parameter :: kind_short = c_short                    !< Short integer kind
+integer,parameter :: kind_real = c_double                    !< Real kind
 
 ! NetCDF kinds
-integer,parameter :: nc_kind_real = nf90_double              ! NetCDF real kind
+integer,parameter :: nc_kind_real = nf90_double              !< NetCDF real kind
 
 ! Huge
-integer,parameter :: huge_int = huge(0_kind_int)             ! Integer huge
-real(kind_real),parameter :: huge_real = huge(0.0_kind_real) ! Real huge
+integer,parameter :: huge_int = huge(0_kind_int)             !< Integer huge
+real(kind_real),parameter :: huge_real = huge(0.0_kind_real) !< Real huge
 
 private
 public kind_int,kind_short,kind_real,nc_kind_real,huge_int,huge_real

--- a/src/saber/util/tools_repro.F90
+++ b/src/saber/util/tools_repro.F90
@@ -13,8 +13,8 @@ use type_mpl, only: mpl_type
 
 implicit none
 
-logical :: repro = .true.                  ! Reproducibility flag
-real(kind_real),parameter :: rth = 1.0e-12 ! Reproducibility threshold
+logical :: repro = .true.                  !< Reproducibility flag
+real(kind_real),parameter :: rth = 1.0e-12 !< Reproducibility threshold
 
 private
 public :: repro,rth

--- a/src/saber/util/type_fieldset.F90
+++ b/src/saber/util/type_fieldset.F90
@@ -67,7 +67,6 @@ type(atlas_functionspace),intent(in),optional :: afunctionspace !< ATLAS functio
 
 ! Local variables
 integer :: iv
-character(len=1024) :: fieldname
 character(len=1024),parameter :: subr = 'fieldset_init'
 type(atlas_field) :: afield
 

--- a/src/saber/util/type_rng.F90
+++ b/src/saber/util/type_rng.F90
@@ -14,13 +14,13 @@ use type_nam, only: nam_type
 
 implicit none
 
-integer,parameter :: default_seed = 140587            !< Default seed
-integer(kind=int64),parameter :: a = 1103515245_int64 !< Linear congruential multiplier
-integer(kind=int64),parameter :: c = 12345_int64      !< Linear congruential offset
-integer(kind=int64),parameter :: m = 2147483648_int64 !< Linear congruential modulo
+integer,parameter :: default_seed = 140587       !< Default seed
+integer(int64),parameter :: a = 1103515245_int64 !< Linear congruential multiplier
+integer(int64),parameter :: c = 12345_int64      !< Linear congruential offset
+integer(int64),parameter :: m = 2147483648_int64 !< Linear congruential modulo
 
 type rng_type
-   integer(kind=int64) :: seed
+   integer(int64) :: seed !< Random number generator seed
 contains
    procedure :: init => rng_init
    procedure :: reseed => rng_reseed

--- a/src/saber/util/type_rng.F90
+++ b/src/saber/util/type_rng.F90
@@ -14,10 +14,10 @@ use type_nam, only: nam_type
 
 implicit none
 
-integer,parameter :: default_seed = 140587            ! Default seed
-integer(kind=int64),parameter :: a = 1103515245_int64 ! Linear congruential multiplier
-integer(kind=int64),parameter :: c = 12345_int64      ! Linear congruential offset
-integer(kind=int64),parameter :: m = 2147483648_int64 ! Linear congruential modulo
+integer,parameter :: default_seed = 140587            !< Default seed
+integer(kind=int64),parameter :: a = 1103515245_int64 !< Linear congruential multiplier
+integer(kind=int64),parameter :: c = 12345_int64      !< Linear congruential offset
+integer(kind=int64),parameter :: m = 2147483648_int64 !< Linear congruential modulo
 
 type rng_type
    integer(kind=int64) :: seed

--- a/test/get_nprocs.py
+++ b/test/get_nprocs.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+"""! Get number of available processors"""
 
 import multiprocessing as mp
 print(mp.cpu_count())

--- a/test/mains/model/model_aro.inc
+++ b/test/mains/model/model_aro.inc
@@ -12,7 +12,7 @@ type(mpl_type),intent(inout) :: mpl      !< MPI data
 type(nam_type),intent(in) :: nam         !< Namelist
 
 ! Local variables
-integer :: img,ilon,ilat,il0,il0_bot,il0_top,ie,its
+integer :: img,ilon,ilat,il0,il0_bot,il0_top,ie
 integer :: ncid,nlon_id,nlat_id,nlev_id,pp_id,lon_id,lat_id,cmask_id,a_id,b_id,fld_id,mask_id
 integer,allocatable :: mask_counter(:)
 real(kind_real) :: dx,dy

--- a/test/mains/type_model.F90
+++ b/test/mains/type_model.F90
@@ -23,8 +23,8 @@ use type_rng, only: rng_type
 
 implicit none
 
-real(kind_real),parameter :: qmin = 1.0e-6        ! Minimum specific humidity value in the log variable change
-character(len=1024) :: zone = 'C+I'               ! Computation zone for AROME ('C', 'C+I' or 'C+I+E')
+real(kind_real),parameter :: qmin = 1.0e-6 !< Minimum specific humidity value in the log variable change
+character(len=1024) :: zone = 'C+I'        !< Computation zone for AROME ('C', 'C+I' or 'C+I+E')
 
 ! Model derived type
 type model_type

--- a/tools/saber_plot.py
+++ b/tools/saber_plot.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+"""! Plot management script"""
 
 import argparse
 import os

--- a/tools/saber_plot/avg.py
+++ b/tools/saber_plot/avg.py
@@ -9,6 +9,8 @@ import numpy.ma as ma
 import os
 
 def avg(testdata, test, mpi, omp, suffix, testfig):
+   """! Plot script for the "average" files produced by BUMP"""
+
    # Open file
    f = Dataset(testdata + "/" + test + "/test_" + mpi + "-" + omp + "_" + suffix + ".nc", "r", format="NETCDF4")
 

--- a/tools/saber_plot/contour_centered.py
+++ b/tools/saber_plot/contour_centered.py
@@ -11,6 +11,8 @@ import numpy.ma as ma
 import os
 
 def contour_centered(testdata, test, mpi, omp, suffix, testfig):
+   """! Plot script for the "centered countour" files produced by BUMP"""
+
    # Open file
    f = Dataset(testdata + "/" + test + "/test_" + mpi + "-" + omp + "_" + suffix + ".nc", "r", format="NETCDF4")
 

--- a/tools/saber_plot/contour_positive.py
+++ b/tools/saber_plot/contour_positive.py
@@ -11,6 +11,8 @@ import numpy.ma as ma
 import os
 
 def contour_positive(testdata, test, mpi, omp, suffix, testfig):
+   """! Plot script for the "positive countour" files produced by BUMP"""
+
    # Open file
    f = Dataset(testdata + "/" + test + "/test_" + mpi + "-" + omp + "_" + suffix + ".nc", "r", format="NETCDF4")
 

--- a/tools/saber_plot/diag.py
+++ b/tools/saber_plot/diag.py
@@ -9,6 +9,8 @@ import numpy.ma as ma
 import os
 
 def diag(testdata, test, mpi, omp, suffix, testfig):
+   """! Plot script for the "diagnostic" files produced by BUMP"""
+
    # Open file
    f = Dataset(testdata + "/" + test + "/test_" + mpi + "-" + omp + "_" + suffix + ".nc", "r", format="NETCDF4")
 

--- a/tools/saber_plot/lct_cor.py
+++ b/tools/saber_plot/lct_cor.py
@@ -11,6 +11,8 @@ import numpy.ma as ma
 import os
 
 def lct_cor(testdata, test, mpi, omp, suffix, testfig):
+   """! Plot script for the "LCT correlation" files produced by BUMP"""
+
    # Processor, index and level to plot
    iproc_plot = 1
    ic1a_plot = 1

--- a/tools/saber_plot/normality.py
+++ b/tools/saber_plot/normality.py
@@ -9,6 +9,8 @@ import numpy.ma as ma
 import os
 
 def normality(testdata, test, mpi, omp, suffix, testfig):
+   """! Plot script for the "normality" files produced by BUMP"""
+
    # Loop over files
    first = True
    for impi in range(0, int(mpi)):

--- a/tools/saber_plot/randomization.py
+++ b/tools/saber_plot/randomization.py
@@ -9,6 +9,8 @@ import numpy.ma as ma
 import os
 
 def randomization(testdata, test, mpi, omp, suffix, testfig):
+   """! Plot script for the "randomization" files produced by BUMP"""
+
    # Open file
    f = Dataset(testdata + "/" + test + "/test_" + mpi + "-" + omp + "_" + suffix + ".nc", "r", format="NETCDF4")
 

--- a/tools/saber_plot/sampling_grids.py
+++ b/tools/saber_plot/sampling_grids.py
@@ -11,6 +11,8 @@ import numpy.ma as ma
 import os
 
 def sampling_grids(testdata, test, mpi, omp, suffix, testfig):
+   """! Plot script for the "sampling grids" files produced by BUMP"""
+
    # c3 plot
    ic3_plot = [0,2,4,8]
 

--- a/tools/saber_plot/umf.py
+++ b/tools/saber_plot/umf.py
@@ -9,6 +9,8 @@ import numpy.ma as ma
 import os
 
 def umf(testdata, test, mpi, omp, suffix, testfig):
+   """! Plot script for the "univariate moments fields"  files produced by BUMP"""
+
    # Open file
    f = Dataset(testdata + "/" + test + "/test_" + mpi + "-" + omp + "_" + suffix + ".nc", "r", format="NETCDF4")
 


### PR DESCRIPTION
## Description

This PR cleans some Doxygen comments and removes GNU 9.3.0 compiler warnings (unused variables or arguments).

## Definition of Done

More detailed Doxygen documentation, (almost) no more compiler warnings.

### Issue(s) addressed

None.

## Dependencies

None.

## Impact

None.